### PR TITLE
Fix using purify video as a single HTML file

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
   <header>
     <h1>purify video</h1>
     <h2>Watch purified YouTube videos with no ads. Just focus</h2>
-    <form method="get" action="/">
+    <form method="get" action="">
       <input type="text" name="v" placeholder="Enter YouTube URL" />
       <button type="submit">Purify</button>
     </form>


### PR DESCRIPTION
This PR fixes downloading index.html and using it as a standalone HTML file. Mainly useful for development. ~~I have not tested it with a normal web server or GitHub Pages.~~ I tested it with GitHub Pages [here](amsam0.github.io/purify-video.github.io), and it works fine (in my testing).