### PR TITLE
Don't fail silently and fix lack of protocol failing to parse

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,29 +239,44 @@
       setThemeFromPreference();
       const params = new URLSearchParams(window.location.search.substring(1));
       if (params.has('v')) {
-        const url = new URL(params.get('v'));
-        const urlParams = new URLSearchParams(url.search.substring(1));
-        // See https://developers.google.com/youtube/player_parameters for supported parameters
-        const outputParams = new URLSearchParams();
+        try {
+          let rawUrl = params.get('v');
 
-        if (urlParams.has('t')) {
-          outputParams.append('start', urlParams.get('t'));
-        }
-
-        if (url.hostname == 'youtube.com' || url.hostname.endsWith('.youtube.com')) {
-          if (urlParams.has('list')) {
-            outputParams.append('listType', 'playlist');
-            outputParams.append('list', urlParams.get('list'));
+          // URL parsing will fail if there is no protocol
+          if (!rawUrl.split(".")[0].includes("://")) {
+            rawUrl = "https://" + rawUrl;
           }
 
-          let id = '';
-          if (urlParams.has('v')) {
-            id = urlParams.get('v');
+          const url = new URL(rawUrl);
+          const urlParams = new URLSearchParams(url.search.substring(1));
+          // See https://developers.google.com/youtube/player_parameters for supported parameters
+          const outputParams = new URLSearchParams();
+
+          if (urlParams.has('t')) {
+            outputParams.append('start', urlParams.get('t'));
           }
-          purify(id, outputParams);
-        } else if (url.hostname == 'youtu.be') {
-          const id = url.pathname.substring(1);
-          purify(id, outputParams);
+
+          if (url.hostname == 'youtube.com' || url.hostname.endsWith('.youtube.com')) {
+            if (urlParams.has('list')) {
+              outputParams.append('listType', 'playlist');
+              outputParams.append('list', urlParams.get('list'));
+            }
+
+            let id = '';
+            if (urlParams.has('v')) {
+              id = urlParams.get('v');
+            }
+            purify(id, outputParams);
+          } else if (url.hostname == 'youtu.be') {
+            const id = url.pathname.substring(1);
+            purify(id, outputParams);
+          } else {
+            throw "Unknown hostname";
+          }
+        } catch (e) {
+          setTimeout(() => alert("Failed to parse URL. Please make sure the URL is a valid YouTube video or playlist."), 500);
+          // Also show it in the console
+          throw e;
         }
       }
     }


### PR DESCRIPTION
This PR will show an alert if a URL fails to parse. It also fixes URLs without protocols (e.g. `www.youtube.com/watch?v=...` instead of `https://www.youtube.com/watch?v=...`) failing to parse by attempted to add the `https` protocol to the beginning of the URL if it cannot find a `://` string near the beginning of the URL.